### PR TITLE
Adjusts gtk2.0, ranger, oh-my-zsh and geany configs

### DIFF
--- a/etc/skel/.config/geany/geany.conf
+++ b/etc/skel/.config/geany/geany.conf
@@ -112,9 +112,9 @@ pref_toolbar_use_gtk_default_style=true
 pref_toolbar_use_gtk_default_icon=true
 pref_toolbar_icon_style=0
 pref_toolbar_icon_size=0
-pref_template_developer=Alan Chiapetta
+pref_template_developer=
 pref_template_company=
-pref_template_mail=alan@big
+pref_template_mail=
 pref_template_initial=AC
 pref_template_version=1.0
 pref_template_year=%Y
@@ -197,27 +197,4 @@ scrollback_lines=500
 shell=/bin/bash
 colour_fore=#FFFFFF
 colour_back=#000000
-last_dir=/home/alan
 
-[tools]
-terminal_cmd=xterm -e "/bin/sh %c"
-browser_cmd=firefox
-grep_cmd=grep
-
-[printing]
-print_cmd=
-use_gtk_printing=true
-print_line_numbers=true
-print_page_numbers=true
-print_page_header=true
-page_header_basename=false
-page_header_datefmt=%c
-
-[project]
-session_file=
-project_file_path=/home/alan/projects
-
-[files]
-recent_files=/home/alan/.config/geany/filedefs/filetypes.README;/home/alan/pacotes-biglinux-bspwm-aur.txt;/home/alan/.config/geany/colorschemes/geany/.editorconfig;
-recent_projects=
-current_page=-1

--- a/etc/skel/.config/oh-my-zsh/tools/check_for_upgrade.sh
+++ b/etc/skel/.config/oh-my-zsh/tools/check_for_upgrade.sh
@@ -11,7 +11,7 @@ fi
 # - reminder: a reminder is shown to the user when it's time to update
 # - disabled: automatic update is turned off
 zstyle -s ':omz:update' mode update_mode || {
-  update_mode=prompt
+  update_mode=disabled
 
   # If the mode zstyle setting is not set, support old-style settings
   [[ "$DISABLE_UPDATE_PROMPT" != true ]] || update_mode=auto

--- a/etc/skel/.config/ranger/rc.conf
+++ b/etc/skel/.config/ranger/rc.conf
@@ -1,70 +1,11 @@
-## Copyright (C) 2020-2022 Aditya Shakya <adi1090x@gmail.com>
-
 # Use non-default path for file preview script?
 # ranger ships with scope.sh, a script that calls external programs (see
 # README.md for dependencies) to preview images, archives, etc.
 set preview_script ~/.config/ranger/scope.sh
-
-# Use the external preview script or display simple plain text or image previews?
-set use_preview_script true
-
-# Be aware of version control systems and display information.
-set vcs_aware false
 
 # Use one of the supported image preview protocols
 set preview_images true
 
 set preview_images_method ueberzug
 
-# Use a unicode "..." character to mark cut-off filenames?
-set unicode_ellipsis true
-
-# Which colorscheme to use?  These colorschemes are available by default:
-# default, jungle, snow, solarized
-set colorscheme solarized
-
-# Draw the status bar on top of the browser window (default: bottom)
-set status_bar_on_top false
-
-# Draw borders around columns?
-set draw_borders true
-
-# Display the directory name in tabs?
-set dirname_in_tabs true 
-
-# Enable this if key combinations with the Alt Key don't work for you.
-# (Especially on xterm)
-set xterm_alt_key false
-
-# Use fuzzy tab completion with the "cd" command. For example,
-# ":cd /u/lo/b<tab>" expands to ":cd /usr/local/bin".
-set cd_tab_fuzzy true
-
-# Save tabs on exit
-set save_tabs_on_exit true
-
-# Enable scroll wrapping - moving down while on the last item will wrap around to
-# the top and vice versa.
-set wrap_scroll true
-
-# Column ratio
-set column_ratios 2,2,4
-
-# Hidden filter
-set hidden_filter ^\.|\.(?:pyc|pyo|bak|swp)$|^lost\+found$|^__(py)?cache__$
-
-# Color scheme
-set colorscheme default
-
-# ===================================================================
-# == Local Options
-# ===================================================================
-setlocal path=~/Downloads sort mtime
-
-# Moving
-map gT cd "~/.Trash"
-
-# trash lives in ~/.local/share/Trash/files
-map <DELETE> shell -d trash-put %s
-map x shell -d trash-put %s
 

--- a/etc/skel/.gtkrc-2.0.mine
+++ b/etc/skel/.gtkrc-2.0.mine
@@ -1,7 +1,3 @@
-# DO NOT EDIT! This file will be overwritten by LXAppearance.
-# Any customization should be done in ~/.gtkrc-2.0.mine instead.
-
-include "/home/alan/.gtkrc-2.0.mine"
 gtk-theme-name="Catppuccin-Mocha-Standard-Blue-Dark"
 gtk-icon-theme-name="Papirus-Dark"
 gtk-font-name="Cantarell 11"


### PR DESCRIPTION
- remove ~/.gtk-2.0 and add ~/.gtk-2.0.mine instead
- remove auto-update from oh-my-zsh
- reset user configs from Geany
- review and adjsts of Ranger Config (~/.config/ranger/rc.conf)